### PR TITLE
[모던 자바 인 액션] 2장 람다 표현식

### DIFF
--- a/modern-java-in-action/src/main/java/lambda/BufferedReaderProcessor.java
+++ b/modern-java-in-action/src/main/java/lambda/BufferedReaderProcessor.java
@@ -2,7 +2,7 @@ package lambda;
 
 import java.io.BufferedReader;
 import java.io.IOException;
-
+// 250312
 @FunctionalInterface
 public interface BufferedReaderProcessor {
     String process(BufferedReader br) throws IOException;

--- a/modern-java-in-action/src/main/java/lambda/FileProcessor.java
+++ b/modern-java-in-action/src/main/java/lambda/FileProcessor.java
@@ -1,7 +1,7 @@
 package lambda;
 
 import java.io.*;
-
+// 250312
 public class FileProcessor {
     public static String processFile(BufferedReaderProcessor bufferedReaderProcessor) throws IOException {
         InputStream fileResourceAsStream = FileProcessor.class.getClassLoader().getResourceAsStream("data.txt");

--- a/modern-java-in-action/src/main/java/lambda/functionalInterface/ConsumerProcess.java
+++ b/modern-java-in-action/src/main/java/lambda/functionalInterface/ConsumerProcess.java
@@ -2,7 +2,7 @@ package lambda.functionalInterface;
 
 import java.util.List;
 import java.util.function.Consumer;
-
+// 250312
 public class ConsumerProcess {
     public static <T> void foreach(List<T> list, Consumer<T> c) {
         for (T t : list) {

--- a/modern-java-in-action/src/main/java/lambda/functionalInterface/FunctionProcess.java
+++ b/modern-java-in-action/src/main/java/lambda/functionalInterface/FunctionProcess.java
@@ -3,7 +3,7 @@ package lambda.functionalInterface;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
-
+// 250312
 public class FunctionProcess {
 
     public static <T, R>List<R> map(List<T> list, Function<T, R> f) {

--- a/modern-java-in-action/src/main/java/lambda/functionalInterface/IntPredicate.java
+++ b/modern-java-in-action/src/main/java/lambda/functionalInterface/IntPredicate.java
@@ -1,5 +1,5 @@
 package lambda.functionalInterface;
-
+// 250312
 @FunctionalInterface
 public interface IntPredicate {
     boolean test(int t);

--- a/modern-java-in-action/src/main/java/lambda/functionalInterface/PredicateProcess.java
+++ b/modern-java-in-action/src/main/java/lambda/functionalInterface/PredicateProcess.java
@@ -3,7 +3,7 @@ package lambda.functionalInterface;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Predicate;
-
+// 250312
 public class PredicateProcess {
     public static <T>List<T> filter(List<T> list, Predicate<T> p) {
         List<T> result = new ArrayList<>();

--- a/modern-java-in-action/src/test/java/lambda/ExecuteAroundPatternTest.java
+++ b/modern-java-in-action/src/test/java/lambda/ExecuteAroundPatternTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.BufferedReader;
 import java.io.IOException;
-
+// 250312
 public class ExecuteAroundPatternTest {
 
     @Test

--- a/modern-java-in-action/src/test/java/lambda/MethodReferenceTest.java
+++ b/modern-java-in-action/src/test/java/lambda/MethodReferenceTest.java
@@ -11,7 +11,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.function.Predicate;
-
+// 250312
 public class MethodReferenceTest {
 
     private List<Apple> apples = new ArrayList<>();

--- a/modern-java-in-action/src/test/java/lambda/TypeInferenceTest.java
+++ b/modern-java-in-action/src/test/java/lambda/TypeInferenceTest.java
@@ -4,7 +4,7 @@ import behavior_parameterization.Apple;
 import org.junit.jupiter.api.Test;
 
 import java.util.Comparator;
-
+// 250312
 public class TypeInferenceTest {
 
     @Test

--- a/modern-java-in-action/src/test/java/lambda/avoidautoboxing/AvoidAutoBoxingTest.java
+++ b/modern-java-in-action/src/test/java/lambda/avoidautoboxing/AvoidAutoBoxingTest.java
@@ -5,7 +5,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.function.Predicate;
-
+// 250312
 public class AvoidAutoBoxingTest {
 
     @Test

--- a/modern-java-in-action/src/test/java/lambda/functionalInterface/FunctionalInterfaceTest.java
+++ b/modern-java-in-action/src/test/java/lambda/functionalInterface/FunctionalInterfaceTest.java
@@ -7,7 +7,7 @@ import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
-
+// 250312
 class FunctionalInterfaceTest {
     @Test
     void Predicate_함수는_T_객체를_받아_Boolean_을_반환할_때_사용한다() {


### PR DESCRIPTION
# 람다 표현식

## 람다란 무엇인가

람다 표현식은 메서드로 전달할 수 있는 익명의 함수를 단순화한 것이다. (메서드의 한계 극복)

- 인수로 전달할 수 있음
- 변수로 저장할 수 있음
- 이름이 없음
- 간결함
- 클래스에 종속되지 않음

람다 표현식은 파라미터, 화살표, 바디로 이루어져 있다.

```java
// 차례대로 람다 파라미터, 화살표, 람다 바디

(Apple a1, Apple a2) -> a1.getWeight().compareTo(a2.getWeight());
```

## 람다 표현식의 사용처

함수형 인터페이스라는 문맥에서 람다 표현식을 사용할 수 있다.
> 함수형 인터페이스란, 정확히 하나의 추상 메서드를 지정하는 인터페이스를 말한다. 
> 자바 API 의 함수형 인터페이스로는 Comparator, Runnable 등이 있다.

```java
public interface Predicate<T> {
    boolean test(T t);
}
public interface Comparator<T> {
    int compare(T o1, T o2);
}
public interface  Runnable {
    void run();
}
public interface Callable<V> {
    V call() throws Exception;
}
```
> 참고로 인터페이스의 디폴트 메서드에 상관없이 추상 메서드가 오직 하나라면 함수형 인터페이스이다.

다음과 같이 하나의 추상메서드를 갖는 인터페이스, 즉 함수형 인터페이스를 선언한 경우 별도의 구현 클래스 없이 
람다 표현식을 통해 추상 메서드의 구현을 전달할 수 있다.

```java
// 전체 표현식 자체가 함수형 인터페이스의 인스턴스로 취급이 가능하다고 볼 수 있음
Runnable r1 = () -> System.out.println("Hello");

public static void process(Runnable r){
    r.run(); // 람다 표현식으로 정의한 인스턴스가 실행됨
}

process(r1); // Hello 출력
```

## 함수 디스크립터

함수 디스크립터는 람다 표현식의 시그니처를 서술하는 메서드를 말한다. 그리고 함수형 인터페이스의 추상 메서드 시그니처는 람다 표현식의 시그니처를 가리킨다.

```java
public void process(Runnable r);

process(() -> System.out.println("Is Good~~!"));
```

위와 같은 예제에서 `() -> System.out.println("Is Good~~!)` 는 람다 표현식으로, 이 람다 표현식은 Runnable 인터페이스(함수형 인터페이스)의 run 메서드 시그니처와 같다.
자세하게 표현하자면 `Runnable 인터페이스는 인수와 반환값이 없는 시그니처` 이며, 이 시그니처는 람다 표현식의 시그니처를 뜻한다.

- Runnable 인터페이스의 run 메서드를 서술하고 있는 메서드
- 함수 디스크립터

라고 정의할 수 있다.

앞서 함수형 인터페이스를 인수로 받는 메서드에만 람다 표현식을 사용할 수 있다고 했다. 그렇게 설계한 이유는 다음과 같다.

- 자바의 사용자가 하나의 추상 메서드를 갖는 인터페이스에 익숙하다.
- 덜 복잡하다.

## FunctionalInterface

개발하다보면 이따금씩 마주하는 어노테이션이다. 이는 해당 인터페이스가 함수형 인터페이스임을 가리키는 어노테이션이다. 
@FunctionalInterface 를 선언한 인터페이스의 추상 메서드가 한 개 이상이라면 컴파일 시점에 에러가 발생한다.

## 실행 어라운드 패턴

자원 처리 (예를 들어 DB 의 파일처리)에 사용되는 순환 패턴은 다음과 같은 순서로 이루어진다.

1. 자원을 연다.
2. 자원을 처리한다. (실제 자원을 처리하는 코드)
3. 자원을 닫는다.

이와 같이 실제 자원을 처리하는 코드를 설정과 정리 두 과정이 둘러 싸는 형태를 갖는 패턴을 실행 어라운드 패턴이라고 부른다 .

다음은 실행 어라운드 패턴을 적용한 예시다.

```java
@FunctionalInterface
public interface BufferedReaderProcessor {
    String process(BufferedReader br) throws IOException;
}

public class FileProcessor {
    public static String processFile(BufferedReaderProcessor bufferedReaderProcessor) throws IOException {
        InputStream fileResourceAsStream = FileProcessor.class.getClassLoader().getResourceAsStream("data.txt");
        try(BufferedReader br = new BufferedReader(new InputStreamReader(fileResourceAsStream))) {
            return bufferedReaderProcessor.process(br);
        }
    }
}

```

먼저 FileProcessor.processFile 매서드의 파라미터를 함수형 인터페이스 BufferedReaderProcessor 의 인스턴스를 받도록 동작 파라미터화하였다.
(이를 통해 런타임 시점에 인스턴스안에 캡슐화되어 있는 `동작` 이 전달되어 실행될 수 있다) 

이후 아래와 같은 실행 어라운드 패턴을 통해 전체 프로세스가 처리된다.

1. 파일 처리 관련 자바 함수를 통해 파일을 읽는다. (자원을 연다)
2. 우리가 정의한 함수가 실행된다. (자원을 처리한다)
3. try 절이 끝나면 BufferedReader(new InputStreamReader) 를 통해 할당받은 자원을 반환한다. (자원을 반환하다)

위와 같이 정의된 프로세스는 아래와 같이 람다를 전달받아 동적으로 처리된다. 이는 보다 유연하고, 생산적이고, 재활용가능하며 유연하다. 

```java
    @Test
    void 실행_어라운드_패턴_테스트() throws IOException {
        String s = FileProcessor.processFile((BufferedReader br) -> br.readLine());
        Assertions.assertEquals("모던", s);
    }

    @Test
    void 실행_어라운드_패턴_테스트2() throws IOException {
        String s = FileProcessor.processFile((BufferedReader br) -> br.readLine() + br.readLine());
        Assertions.assertEquals("모던자바", s);
    }
```

## 함수형 인터페이스의 활용

앞서 언급했듯, 함수형 인터페이스는 오직 하나의 추상 메서드를 정의해야한다. 
> 프로그래머가 통상적으로 그렇게 사용하기에 익숙하며, 간결하기 때문에

함수형 인터페이스의 추상 메서드는 람다 표현식의 시그니처를 묘사한다고 설명했었다. 
> 예를 들어 Runnable 의 추상 메서드 run 을 살펴보면 람다 표현식이 어떻게 구성될지 알 수 있다.

다양한 람다 표현식을 사용하려면 공통의 함수 디스크립터를 기술하는 함수형 인터페이스 집합이 필요하다. 자바 API 는 이미 Callable, Runnable, Comparable 과 같은
다양한 함수형 인터페이스를 제공하고 있따.

이들은 모두 `java.util.function` 패키지에 포함되어 있으며, 자바 API 는 이 밖에도 여러가지 새로운 함수형 인터페이스를 제공한다.

이 중 보다 대중적으로 사용되는 3 가지 함수형 인터페이스에 대해 알아보자.

### 1. Predicate

Predicate<T> 인터페이스는 test 라는 추상 메서드를 정의하며, 다음과 같이 T 형식의 객체를 사용하는 Boolean 표현식이 필요한 상황에서 사용할 수 있다.

```java
public class PredicateProcess {
    public static <T>List<T> filter(List<T> list, Predicate<T> p) {
        List<T> result = new ArrayList<>();
        for(T t : list) {
            if(p.test(t)) {
                result.add(t);
            }
        }
        return result;
    }
}

```

### 2. Consumer

Consumer<T> 인터페이스는 제네릭 형식 T 객체를 받는 반환형이 없는 accept 메서드를 제공한다. T 형식의 객체를 인수로 받아 어떤 동작을 수행하고자 할 떄 사용한다.

```java
public class ConsumerProcess {
    public static <T> void foreach(List<T> list, Consumer<T> c) {
        for (T t : list) {
            c.accept(t);
        }
    }
}
```

### 3. Function 

Function<T, R> 인터페이스는 제네릭 형식 T 을 인수로 받아 R 형식 객체를 반환하는 추상 메서드 apply 를 제공한다. 입력을 출력으로 매핑하는 람다를 정의할 떄 사용한다.

```java
public class FunctionProcess {

    public static <T, R>List<R> map(List<T> list, Function<T, R> f) {
        List<R> result = new ArrayList<>();
        for (T t : list) {
            result.add(f.apply(t));
        }
        return result;
    }
}

```

## 기본형 특화 

위 3 개의 제네릭 함수형 인터페이스 외에도 특화된 형식의 함수형 인터페이스도 존재한다. 

자바의 모든 형식은 원시타입과 참조타입으로 나뉘는데 위의 예시들에서 사용한 함수형 인터페이스들은 
모두 Wrapper 타입만을 사용할 수 있다. 

자바에서는 참조타입과 원시타입간의 변환을 위해 박싱과 언박싱, 오토박싱을 제공하지만 박싱한 값은 
기본적으로 원시타입을 감싸서 Heap 영역에 저장되기 다음과 같은 단점을 가진다.

- 메모리를 더 사용한다.
- 다시 기본형을 가져올 때에도 메모리를 탐색하는 비용이 필요하다.

위 문제점은 결국 사용자가 의도하지 않은 박싱이 일어날 때 발생하는 것으로, 주로 오토박싱에서 발생한다.

```java
@FunctionalInterface
public interface IntPredicate {
    boolean test(int t);
}

```

위 예시에서 IntPredicate 를 사용할 때에는 당연히 오토박싱이 일어나지 않는다. 하지만 Predicate<T> 를 사용할 때에는
참조 타입이기 때문에 인자에 원시타입을 전달하면 오토박싱이 일어난다. 

자바 8 에서는 특정 형식을 입력 받는 함수형 인터페이스를 지원하고, 이러한 인터페이스 이름 앞에 
`DoublePredicate`, `IntConsumer`, `IntFunction` 과 같은 형식명이 붙는다. 

기본형 특화 함수형 인터페이스에 대해 모두 나열하기에는 너무 많으니 자세한 내용은 자바 공식문서를 참고하자.

> 함수형 인터페이스는 checked exception 을 허용하지 않는다. 그렇기에 해당 예외를 던지기 위해서는 checked exception 
> 을 선언하는 함수형 인터페이스를 직접 정의하거나 람다를 try~catch 블록안에 감싸야한다.

## 형식 검사, 형식 추론, 제약
> 컴파일러가 람다 형식을 어떻게 확인할까, 또 피해야하는 사항은 무엇일까?

람다 표현식으로 함수형 인터페이스의 인스턴스를 만들 수 있다. 하지만 람다 표현식 자체에는 어떤 함수형 인터페이스를 구현하는지에 대한
정보는 들어있지 않다. 즉, 컴파일러가 형식을 검사하고 형식을 추론하는 과정을 거치기에 함수형 인터페이스의 인스턴스를 생성할 수 있는 것이다.

### 형식 검사

컴파일러가 람다의 형식을 검사를 할 때에는 람다가 사용되는 Context 를 이용한다. 그리고 이 Context 에서
기대되는 람다 표현식의 형식을 `대상 형식`이라고 한다.

```java
filter(inventory, (Apple apple) -> apple.getWeight() > 0);
```

1. filter 메서드의 선언을 확인한다.
2. filter 메서드는 두 번째 파라미터로 Predicate<Apple> 형식(대상 형식)을 기대한다.
3. Predicate<Apple> 은 test 라는 추상 메서드를 갖는 함수형 인터페이스이다.
4. test 메서드는 Apple 을 받아 boolean 을 반환하는 함수 디스크립터를 묘사한다.
5. filter 메서드로 전달된 인수는ㅇ이와 같은 요구사항을 만족해야한다. 

요약하자면, 결국 람다가 사용된 Context 가 무엇인지를 확인하기 위해 람다식이 전달되는 메서드의 정의를 확인하고
이를 통해 대상 형식을 확인한다. 대상 형식(람다 표현식 기대값)이 확인되면, 마지막으로 해당 함수형 인터페이스에 정의된
추상 메서드를 확인하여 반환 타입과 인자 타입을 확인하여 이를 람다 표현식과 비교하여 옳고 그름을 판단하는 것이다.

결국 대상 형식(람다 표현식 기대값)이라는 특징으로 인해, 람다 표현식은 호환되는 추상메서드를 가진 다른 인터페이스로 사용될 수 있는 것이다.

### 형식 추론

자바 컴파일러는 람다 표현식이 사용된 Context 를 찾아, 해당하는 대상 형식을 이용하여 람다 표현식과 관련된 함수형 인터페이스를 추론한다.

즉, 대상 형식을 이용하여 람수 디스크립터를 알 수 있으므로 컴파일러는 람다의 시그니처도 추론할 수 있다. 결과적으로 람다 표현식에서 파라미터 형식을 제거해도 
컴파일러는 형식을 추론할 수 있다. 이렇게 컴파일러의 형식 추론을 활용하여 람다 문법에서 파라미터 타입을 생략하면 가독성 향상이라는 이점이 있다.

```java
Comparator<Apple> c = (Apple a1, Apple a2) -> a1.getWeight().compareTo(a2.getWeight());
Comparator<Apple> c = (a1, a2) -> a1.getWeight().compareTo(a2.getWeight());
```

물론 명시적으로 타입을 나타내는 것이 좋은 경우도 있기 때문에 상황에 맞게 형식을 생략해야한다.

### 지역 변수

람다 표현식을 통해 익명 함수를 대체했던 것처럼, 람다 표현식은 익명함수처럼 자유 변수를 활용할 수 있다. 
그리고 이와 같은 동작을 람다 캡처링(capturing lambda)이라고 부른다.
> 여기에서 자유 변수는 파라미터로 넘겨받은 변수가 아닌 외부에서 선언된 변수를 의미한다.

```java
int portNum = 1337;
Runnable r = () -> System.out.println(portNum);
```

하지만 자유 변수에도 약간의 제약이 존재하는데, 람다는 인스턴스 변수와 정적 변수를 자유롭게 캡처할 수 있는 만큼 변하지 않는 한번만 할당된 값을 자유 변수로 사용할 수 있다.
즉 명식적으로 final 로 선언하거나 실질적으로 final 로 선언된 값과 동일하게 사용해야한다.

이를 어기면, 컴파일이 불가능하다. 

```java
int portNum = 1337;
Runnable r = () -> System.out.println(portNum);
// portNum = 8080; 재할당 불가능, 컴파일 에러
```

이러한 제약이 존재하는 이유는 지역 변수와 인스턴스 변수의 차이에서 발생한다. 인스턴스 변수는 힙 영역, 지역 변수는 스택 영역에 저장되는데 
람다에서 지역 변수로 바로 접근할 수 있다는 가정하에, 람다가 스레드에서 실행된다면 해당 스레드가 사라져 변수 할당이 해제된 경우에도 람다를 실행된 또 다른 
스레드에서 해당 변수에 접근할 수 있는 가능성이 존재한다. 이를 막기 위해 자바 구현에서는 원래 변수에 접근을 허용하는 것이 아니라 자유 지역 변수의 복사본을 제공하는데 
이 복사본의 값이 바뀌지 않아야 하므로 이와 같은 제약이 존재하는 것이다.

## 메서드 참조


람다 표현식보다 때때로 더 좋은 가독성을 얻을 수 있는 방법으로 메서드 참조가 있다. 

```java
// 람다 표현식
(Apple a1, Apple a2) -> a1.getWeight().compareTo(a2.getWeight();

// 메서드 참조
comparing(Apple::getWeight);
```

메서드 참조는 `람다의 축약형`이라고 생각할 수 있다. 즉, 람다를 보다 편리하게 표현할 수 있는 문법 정도로 
이해하면 된다. 

메서드 참조는 3가지 유형으로 나뉘며, 각각의 예시는 다음과 같다.

### 1. 정적 메서드 참조


```java
    void 정적_메서드_참조() {

        long freshAppleCount = apples.stream()
//                .filter(apple -> Apple.isFresh(apple))
                .filter(Apple::isFresh) // 메서드 참조
                .count();

        Assertions.assertThat(freshAppleCount).isEqualTo(3);
    }
```

### 2. 다양한 형식의 인스턴스 메서드 참조

```java
    void 인스턴스_메서드_참조() {
        List<Integer> nums = Arrays.asList(5, 2, 3, 1, 4);
//        nums.sort((num1, num2) -> num1.compareTo(num2));
        nums.sort(Integer::compareTo);
        Assertions.assertThat(nums.get(0)).isEqualTo(1);
    }
```

### 3. 기존 객체의 인스턴스 메서드 참조

```java
private boolean isValidName(String string) {
    return Character.isUpperCase(string.charAt(0));
}

filter(words, this::isValidName);
```

## 람다 표현식을 조합할 수 있는 유용한 메서드

함수형 인터페이스들은 람다 표현식을 조합할 수 있도록 유틸리티 메서드를 제공한다. 이를 통해 간단한 여러개의 람다 표현식을 조합하여 복잡한 람다 표현식을 만들 수 있으며
한 함수의 결과가 다른 함수의 입력이 되도록 조합할 수도 있다. 
> 함수형 인터페이스는 단 하나의 추상 메서드를 갖는다. 위에서 설명한 유틸리티 메서드는 추상 메서드가 아닌 디폴트 메서드를 통해 실현한 것으로 함수형
> 인터페이스의 정의는 여전히 유효하다.

함수형 인터페이스와 그가 제공하는 유틸리티 메서드를 활용한 예시는 다음과 같다.

### Comparator 조합
```java
    void Comparator_조합_comparing() {
//        apples.sort((a1, a2) -> a1.getWeight().compareTo(a2.getWeight()));
//        Comparator.comparing((Apple a) -> a.getWeight());
//        Function<Apple, Integer> f = (Apple apple) -> apple.getWeight();
        Comparator<Apple> appleComparator = Comparator.comparing(Apple::getWeight);
        apples.sort(appleComparator);
        Assertions.assertThat(apples.get(0).getWeight()).isEqualTo(10);
    }

    void Comparator_조합_reversed() {
            apples.sort(Comparator.comparing(Apple::getWeight).reversed());
            Assertions.assertThat(apples.get(0).getWeight()).isEqualTo(100);
    }

```

### Predicate 조합
```java
    @Test
    void Predicate_조합_negate() {
        Predicate <Apple> isFresh = Apple::isFresh;
        Predicate <Apple> isNotFresh = isFresh.negate();

        long freshCount = apples.stream().filter(isFresh).count();
        long notFreshCount = apples.stream().filter(isNotFresh).count();

        Assertions.assertThat(freshCount).isEqualTo(3);
        Assertions.assertThat(notFreshCount).isEqualTo(2);
    }

    @Test
    void Predicate_조합_or() {
        Predicate<Apple> isFresh = Apple::isFresh;
        Predicate<Apple> isFreshOrHeavy = isFresh.or(Apple::isHeavy);
        long count = apples.stream().filter(isFreshOrHeavy).count();

        Assertions.assertThat(count).isEqualTo(3);
    }
```